### PR TITLE
Lines below headings and image borders

### DIFF
--- a/main.css
+++ b/main.css
@@ -438,6 +438,15 @@ dt {
     margin-right: 2em;
 }
 
+div.thumbinner {
+  border: 1px solid #ccc;
+  padding: 3px !important;
+  background-color: #f9f9f9;
+  font-size: 94%;
+  text-align: center;
+  overflow: hidden;
+}
+
 
 /* fix diff scrollbars */
 table.diff td div {


### PR DESCRIPTION
This will implement lines below the major headings (same ones as in the old style), and puts a border around images.
