### PR TITLE
Call printTrail()

### DIFF
--- a/ScratchWikiSkin.php
+++ b/ScratchWikiSkin.php
@@ -148,6 +148,9 @@ class ScratchWikiSkinTemplate extends BaseTemplate{
 	</ul>
 	<p>Scratch is a project of the Lifelong Kindergarten Group at the MIT Media Lab</p>
 </footer>
+
+        <?php $this->printTrail(); ?>
+
 		<?php
 
 	}


### PR DESCRIPTION
From the docs:

> Output the basic end-page trail including bottomscripts, reporttime, and
> debug stuff.
> 
> This should be called right before outputting the closing body and html tags.

Fixes the ScratchBlocks2 extension.

@jacob-g I reverted to unix line endings for consistency with the other files.
