### PR TITLE
Fix header z-index to be above scratchblocks

### DIFF
--- a/main.css
+++ b/main.css
@@ -18,7 +18,7 @@ header {
 	-moz-box-shadow: 0 1px 1px #ccc;
 	-o-box-shadow: 0 1px 1px #ccc;
 	box-shadow: 0 1px 1px #ccc;
-	z-index: 3;
+	z-index: 200;
 }
 
 


### PR DESCRIPTION
scratchblocks2 uses z-index: ~100-105ish, so the header needs to have a higher z-index so that the blocks don't show through.

(I'm not convinced I really understand z-indexes...)
