### PR TITLE
Fix line-height issue

### DIFF
--- a/main.css
+++ b/main.css
@@ -147,6 +147,7 @@ header li a:hover, #userfcttoggle.open {
 	-o-box-shadow: 0 2px 3px rgba(34,25,25,0.3);
 	box-shadow: 0 2px 3px rgba(34,25,25,0.3);
 	margin: 0px 0px 20px;
+	line-height: 1.5em;
 }
 .box > h1 {
 	margin: 0;


### PR DESCRIPTION
It's been bothering me for a long time. :P 1.5em seems to be the unit used on the normal mediawiki skin we had before, and I think it improves readability.
