### PR TITLE
Fix small graphical glitch

### DIFF
--- a/main.css
+++ b/main.css
@@ -305,7 +305,7 @@ opacity: .8;
 	font-size: 14px;
 	list-style: none;
 	display: none;
-	z-index: 2;
+	z-index: 200;
 	background-color: #DDDDDD;
 	overflow: hidden;
 	border-radius: 5px;


### PR DESCRIPTION
This stops the bottom stub on scratchblocks pieces sometimes appearing above the "pencil" drop-down menu used for edit functions.

http://wiki.scratch.mit.edu/w/index.php?title=User:KrIsMa/Sandbox&oldid=81745
