### PR TITLE
Update ScratchWikiSkin.php

### DIFF
--- a/ScratchWikiSkin.php
+++ b/ScratchWikiSkin.php
@@ -50,7 +50,7 @@ class ScratchWikiSkinTemplate extends BaseTemplate{
 		
 		<ul class="left">
 			<li><a href="http://scratch.mit.edu/projects/editor/">Create</a></li>
-			<li><a href="http://scratch.mit.edu/explore/?date=this_month">Explore</a></li>
+			<li><a href="http://scratch.mit.edu/explore/projects/all">Explore</a></li>
 			<li><a href="http://scratch.mit.edu/discuss/">Discuss</a></li>
 			<li ><a href="http://scratch.mit.edu/about/">About</a></li>
 			<li class = "last"><a href="http://scratch.mit.edu/help/">Help</a></li>


### PR DESCRIPTION
The explore link on the header is broken after an update to the page on the main site. This is the new URL, the old one produces a 403 error. See also: https://wiki.scratch.mit.edu/wiki/Scratch_Wiki_talk:Community_Portal#Explore_link.